### PR TITLE
[MAINTAIN-168] Allow for filtering distance by km on locations page

### DIFF
--- a/config/install/openy_map.settings.yml
+++ b/config/install/openy_map.settings.yml
@@ -1,4 +1,5 @@
 map_engine: leaflet
+distance_limit_units: ml
 leaflet:
   base_layer: OpenStreetMap.Mapnik
   search_icon: 'modules/contrib/openy_map/img/other/map_icon_red.png'

--- a/openy_map.install
+++ b/openy_map.install
@@ -133,3 +133,13 @@ function openy_map_update_8006() {
 function openy_map_update_8007() {
   _openy_map_absolutize_config_icon_urls();
 }
+
+/**
+ * Update distance limit units.
+ */
+function openy_map_update_8008() {
+  $config_factory = \Drupal::configFactory();
+  $config_factory->getEditable('openy_map.settings')
+    ->set('distance_limit_units', 'ml')
+    ->save(TRUE);
+}

--- a/openy_map.module
+++ b/openy_map.module
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 function openy_map_theme() {
   $items = [
     'openy_map' => [
+      '#options' => [],
       'render element' => 'element',
     ],
   ];

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -120,6 +120,19 @@ class SettingsForm extends ConfigFormBase {
       '#default_value' => _openy_map_get_default_location(),
     ];
 
+    $form['distance_limit_units_title'] = [
+      '#markup' => '<h2>' . $this->t('Distance limit units') . '</h2>',
+    ];
+    $form['distance_limit_units'] = [
+      '#type' => 'radios',
+      '#options' => [
+        'ml' => $this->t('Miles'),
+        'km' => $this->t('Kilometers'),
+      ],
+      '#default_value' => !empty($config->get('distance_limit_units')) ? $config->get('distance_limit_units') : 'ml',
+      '#required' => TRUE,
+    ];
+
     $options = [
       'Wikimedia' => [
         'name' => 'Wikimedia',
@@ -336,6 +349,7 @@ class SettingsForm extends ConfigFormBase {
     }
 
     $config->set('map_engine', $form_state->getValue('map_engine'));
+    $config->set('distance_limit_units', $form_state->getValue('distance_limit_units'));
     $config->set('leaflet.location', $form_state->getValue('leaflet')['location']);
     $config->set('leaflet.base_layer', $form_state->getValue('leaflet')['base_layer']);
     $config->set('leaflet.base_layer_override', $form_state->getValue('leaflet')['base_layer_override']);

--- a/src/Plugin/Block/LocationFinderFilters.php
+++ b/src/Plugin/Block/LocationFinderFilters.php
@@ -3,6 +3,7 @@
 namespace Drupal\openy_map\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\openy_socrates\OpenySocratesFacade;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -26,11 +27,19 @@ class LocationFinderFilters extends BlockBase implements ContainerFactoryPluginI
   protected $socrates;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, OpenySocratesFacade $socrates) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OpenySocratesFacade $socrates, ConfigFactoryInterface $config_factory) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->socrates = $socrates;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -41,7 +50,8 @@ class LocationFinderFilters extends BlockBase implements ContainerFactoryPluginI
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('socrates')
+      $container->get('socrates'),
+      $container->get('config.factory')
     );
   }
 
@@ -53,9 +63,38 @@ class LocationFinderFilters extends BlockBase implements ContainerFactoryPluginI
       [
         '#type' => 'openy_map',
         '#show_controls' => TRUE,
+        '#options' => $this->getDistanceMapOptions(),
         '#element_variables' => $this->socrates->getLocationPins(),
       ],
     ];
+  }
+
+  /**
+   * @return array
+   */
+  private function getDistanceMapOptions() {
+    $units_map = [
+      'ml' => 'miles',
+      'km' => 'kilometers',
+    ];
+    $distance_in_miles = [5, 10, 30, 50, 100];
+    $units = $this->configFactory
+      ->get('openy_map.settings')
+      ->get('distance_limit_units');
+    foreach ($distance_in_miles as $miles) {
+      $distance = ($units === 'km') ? $miles * 0.621 : $miles;
+      $options[] = [
+        'value' => $distance,
+        'label' => $this->t('@count @unit',
+          [
+            '@count' => $miles,
+            '@unit' => $units_map[$units],
+          ]
+        ),
+        'selected' => $miles === 10 ? 'selected' : '',
+      ];
+    }
+    return $options;
   }
 
 }

--- a/templates/openy-map.html.twig
+++ b/templates/openy-map.html.twig
@@ -23,12 +23,13 @@
                   <div class="form-group">
                     <label class="sr-only">{{ 'Distance'|t }}</label>
                     <select class="distance_limit_value distance_limit form-control form-select">
-                      <option class="all_locations" value="">{{ 'All locations'|t }}</option>
-                      <option value="5">{{ '5 miles'|t }}</option>
-                      <option value="10" selected>{{ '10 miles'|t }}</option>
-                      <option value="30">{{ '30 miles'|t }}</option>
-                      <option value="50">{{ '50 miles'|t }}</option>
-                      <option value="100">{{ '100 miles'|t }}</option>
+                      <option class="all_locations" value="all_locations">{{ 'All locations' | t }}</option>
+                      {% for option in element['#options'] %}
+                        <option value="{{ option.value }}"
+                          {{ option.selected }}>
+                          {{ option.label }}
+                        </option>
+                      {% endfor %}
                     </select>
                   </div>
                 </div>


### PR DESCRIPTION
Original Issue, this PR is going to fix: [MAINTAIN-168](https://openy.atlassian.net/browse/MAINTAIN-168)

This one should add ability to filters locations by distance in kilometers units
![MAINTAIN-168filterInkilometers](https://user-images.githubusercontent.com/744406/132713174-368bbb43-32ef-4557-93c5-4960ffd995f3.png)

## Steps for review

- [ ] log as admin
- [ ] go to /admin/openy/settings/openy_map
- [ ] verify that you can see a new options **Distance limit units** there 
- [ ] verify that by default it has value in **Miles**
- [ ] please select **Kilometers** option and save the form
![MAINTAIN-168NewOptionsInSettingsForm](https://user-images.githubusercontent.com/744406/132713802-e4d82dc3-b78f-4bbf-938d-e45b4378a8bb.png)

- [ ] go to /locations
- [ ] verify that you can see the distance filter with values in kilometers
- [ ] verify that filters by distance works fine