### PR TITLE
Fix branch amenities filter

### DIFF
--- a/src/OpenyMapDataWrapper.php
+++ b/src/OpenyMapDataWrapper.php
@@ -49,7 +49,7 @@ class OpenyMapDataWrapper extends DataWrapper {
         '/' . drupal_get_path('module', 'openy_map') . "/img/map_icon_green.png";
       $pins[] = [
         'icon' => $uri,
-        'location_id' => $location->id(),
+        'location_id' => (int) $location->id(),
         'tags' => [$tag],
         'lat' => round($coordinates[0]['lat'], 5),
         'lng' => round($coordinates[0]['lng'], 5),


### PR DESCRIPTION
At map.js we have a strict comparison:

`$self.data("openy-map-location-id") === data[i].location_id`

$self.data("openy-map-location-id") returns integer type, and data[i].location_id was described as string

this brokes amenities filter feature