### PR TITLE
Fixed array offset warning on SettingsForm.php

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -229,7 +229,7 @@ class SettingsForm extends ConfigFormBase {
       '#size' => 2,
       '#title' => $this->t('Disable clustering at zoom'),
       '#description' => $this->t('If set, at this zoom level and below, markers will not be clustered.'),
-      '#default_value' => $clustering_settings['disable_clustering_at_zoom'],
+      '#default_value' => $clustering_settings['disable_clustering_at_zoom'] ?? [],
       '#states' => [
         'visible' => $visible,
       ],


### PR DESCRIPTION
```Warning: Trying to access array offset on value of type null in Drupal\openy_map\Form\SettingsForm->buildForm() (line 232 of /var/www/html/docroot/modules/contrib/openy_map/src/Form/SettingsForm.php)```