### PR TITLE
Use renderPlain to ensure lazy_builder placeholders are rendered too.

### DIFF
--- a/src/OpenyMapDataWrapper.php
+++ b/src/OpenyMapDataWrapper.php
@@ -58,7 +58,7 @@ class OpenyMapDataWrapper extends DataWrapper {
         'lat' => round($coordinates[0]['lat'], 5),
         'lng' => round($coordinates[0]['lng'], 5),
         'name' => $location->label(),
-        'markup' => $this->renderer->render($view),
+        'markup' => $this->renderer->renderPlain($view),
       ];
     }
 


### PR DESCRIPTION
After update of **ycloudyusa/yusaopeny** package to **10.2.14.1** the location pins no longer have today's hours displayed:
![image](https://github.com/open-y-subprojects/openy_map/assets/15172796/ae02b5b7-959f-4b38-9b6b-dd3d4c71cb6e)
This is because the today's hours are rendered using lazy_builder, similarly to the https://git.drupalcode.org/project/lb_branch_hours_blocks/-/blob/1.1.x/src/Plugin/Block/BranchHoursBlock.php?ref_type=heads#L184
and the markup looks like this:

```
<div class="today-hours position-relative">
    <div class="information">
      <span class="todays-hours-text pr-1">
        <i class="fas fa-clock pr-2 mr-1"></i><span class="d-inline d-md-none">Today</span><span class="d-none d-md-inline">Today's hours</span>:
      </span>
      <drupal-render-placeholder callback="ymca_branch.hours_today:generateHoursToday" arguments="0=%5B%7B%22Monday%22%3A%225%3A00am%20-%208%3A00pm%22%2C%22Tuesday%22%3A%225%3A00am%20-%208%3A00pm%22%2C%22Wednesday%22%3A%225%3A00am%20-%208%3A00pm%22%2C%22Thursday%22%3A%225%3A00am%20-%208%3A00pm%22%2C%22Friday%22%3A%225%3A00am%20-%208%3A00pm%22%2C%22Saturday%22%3A%228%3A00am%20-%201%3A00pm%22%2C%22Sunday%22%3A%221%3A00pm%20-%205%3A00pm%22%7D%2C%5B%7B%22holiday%22%3A%22Easter%20Sunday%22%2C%22hours%22%3A%22Closed%22%2C%22date_value%22%3A%222023-04-09%22%7D%2C%7B%22holiday%22%3A%22Memorial%20Day%22%2C%22hours%22%3A%228%3A00am-4%3A00pm%22%2C%22date_value%22%3A%222023-05-29%22%7D%2C%7B%22holiday%22%3A%22Independence%20Day%22%2C%22hours%22%3A%228%3A00am-4%3A00pm%22%2C%22date_value%22%3A%222023-07-04%22%7D%2C%7B%22holiday%22%3A%22Labor%20Day%22%2C%22hours%22%3A%228%3A00am-4%3A00pm%22%2C%22date_value%22%3A%222023-09-04%22%7D%2C%7B%22holiday%22%3A%22Thanksgiving%20Day%22%2C%22hours%22%3A%22Closed%22%2C%22date_value%22%3A%222023-11-23%22%7D%2C%7B%22holiday%22%3A%22Christmas%20Eve%22%2C%22hours%22%3A%22Closed%22%2C%22date_value%22%3A%222023-12-24%22%7D%2C%7B%22holiday%22%3A%22Christmas%20Day%22%2C%22hours%22%3A%22Closed%22%2C%22date_value%22%3A%222023-12-25%22%7D%2C%7B%22holiday%22%3A%22New%20Year%5Cu0027s%20Eve%22%2C%22hours%22%3A%221%3A00pm-4%3A00pm%22%2C%22date_value%22%3A%222023-12-31%22%7D%2C%7B%22holiday%22%3A%22New%20Year%5Cu0027s%20Day%22%2C%22hours%22%3A%225%3A00am-4%3A00pm%22%2C%22date_value%22%3A%222024-01-01%22%7D%5D%5D" token="nCcMX1VLACV5nw7k8JsJcBTJ-nZnvV9EgMEKbcln1g0"></drupal-render-placeholder>
    </div>
  </div>
```
![image](https://github.com/open-y-subprojects/openy_map/assets/15172796/0deb740e-f7a5-42cd-a51b-19adeadb6f8f)

From what i can gather, the placeholder is not rendered because we use `$this->renderer->render()`: https://github.com/open-y-subprojects/openy_map/blob/main/src/OpenyMapDataWrapper.php#L61

Earlier, it was renderRoot(): https://github.com/open-y-subprojects/openy_map/commit/952882f819bf788f675e8c43a735dbc1b17c91df
But it caused another problem: https://github.com/open-y-subprojects/openy_map/issues/35
So i propose to use `renderPlain()`, this way the placeholders are rendered and no bubbling of attachments happens.