### PR TITLE
fix: 500 error on standard profile 

### DIFF
--- a/modules/openy_map_lb/src/Plugin/Block/LocationFinder.php
+++ b/modules/openy_map_lb/src/Plugin/Block/LocationFinder.php
@@ -158,7 +158,7 @@ class LocationFinder extends BlockBase implements ContainerFactoryPluginInterfac
       'items' => [],
     ];
     $terms = $this->taxonomyStorage->loadTree(self::AMENITIES_VOCABULARY, 0, 2, TRUE);
-    $max_depth = max(array_column($terms, 'depth'));
+    $max_depth = empty($terms) ? 0 : max(array_column($terms, 'depth'));
     if ($max_depth > 0) {
       $result['type'] = 'groups';
     }


### PR DESCRIPTION
Fix 500 error on `/demo-location-finder` path after install standard YUSAOpenY profile
```
ValueError: max(): Argument #1 ($value) must contain at least one element in max()...
```