### PR TITLE
Use bundle label instead of machine name

### DIFF
--- a/modules/openy_map_lb/openy_map_lb.module
+++ b/modules/openy_map_lb/openy_map_lb.module
@@ -128,4 +128,9 @@ function openy_map_lb_preprocess_node__location_type__lb_teaser(&$variables) {
     ]
   ];
   $variables['#attached']['drupalSettings']['lb_branch_hours_blocks']['branch_hours'][$node->id()] = $branch_hours['js_settings'];
+
+  // Use the bundle label, not the machine name, to respect translation and 
+  // changes to the name made in bundle config.
+  // via https://drupal.stackexchange.com/a/187983/24177
+  $variables['bundle_label'] = $node->type->entity->label();
 }

--- a/modules/openy_map_lb/templates/node--location-type--lb-teaser.html.twig
+++ b/modules/openy_map_lb/templates/node--location-type--lb-teaser.html.twig
@@ -99,7 +99,7 @@
 
         <div class="type">
           {% include "@openy_map_lb/svg/map_icon.html.twig" %}
-          {{ node.bundle }}
+          {{ bundle_label }}
         </div>
 
         <div{{ content_attributes.addClass('node__content') }}>


### PR DESCRIPTION
The bundle label previously pulled the machine name of the bundle, not its label. This pulls the label instead, so that translations and other changes in the label name (like changing "Branch" to "Fitness Center", for example) are respected.

<img width="640" alt="SCR-20241205-knds" src="https://github.com/user-attachments/assets/8e07ac91-7a28-46d6-93c9-65fc6d0d3bdf">

via YMCA of the National Capital Region