### PR TITLE
Add empty check for hours

### DIFF
--- a/modules/openy_map_lb/templates/node--location-type--lb-teaser.html.twig
+++ b/modules/openy_map_lb/templates/node--location-type--lb-teaser.html.twig
@@ -113,7 +113,7 @@
                   {{ "Phone"|t }} {{ content.field_location_phone }}
                 </div>
             {% endif %}
-            {% if content.field_branch_hours %}
+            {% if content.field_branch_hours and node.field_branch_hours.value is not empty %}
                 <div class="hours">
                   {% include "@openy_map_lb/svg/clock_icon.html.twig" %}
                   {{ content.field_branch_hours }}</div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d9bd126-17cd-4b1b-b664-546f6e2228ab)

If the hours field is empty, the hours icon will still appear. This ensures we're checking for empty properly.