### PR TITLE
chore(openy_map_lb): don't use dynamic property

### DIFF
--- a/modules/openy_map_lb/src/Plugin/Block/LocationFinder.php
+++ b/modules/openy_map_lb/src/Plugin/Block/LocationFinder.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\openy_socrates\OpenySocratesFacade;
+use Drupal\taxonomy\TermStorageInterface;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -45,6 +46,11 @@ class LocationFinder extends BlockBase implements ContainerFactoryPluginInterfac
    * @var \Drupal\Core\Language\LanguageManagerInterface
    */
   protected $languageManager;
+
+  /**
+   * The taxonomy term storage.
+   */
+  protected TermStorageInterface $taxonomyStorage;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
It triggers a deprecation with PHP>=8.2, `Creation of dynamic property is deprecated`.

Thanks!